### PR TITLE
Make resource urls bilingual

### DIFF
--- a/datasets/mhmelih16.toml
+++ b/datasets/mhmelih16.toml
@@ -49,9 +49,16 @@ text = "An index of Iranian hospitals. This dataset is disaggregated by province
 
 [[resources]]
 
-  url = "http://iod.dataset.s3.amazonaws.com/mhmellih16/mhmellih16fa.csv"
   name = "mhmelih16"
   code = "https://github.com/iranopendata/ingest/blob/master/ruby/mhmellih16.rb"
+
+  [[resources.url]] 
+  lang = "fa"
+  link = "http://iod.dataset.s3.amazonaws.com/mhmellih16/mhmellih16fa.csv"
+
+  [[resources.url]] 
+  lang = "en"
+  link = "http://iod.dataset.s3.amazonaws.com/mhmellih16/mhmellih16en.csv"
 
   [[resources.title]]
   lang = "en"

--- a/datasets/nocrcd1685.toml
+++ b/datasets/nocrcd1685.toml
@@ -51,7 +51,9 @@ text = ""
 
 [[resources]]
 
-  url = "http://iod.dataset.s3.amazonaws.com/nocrd/NOCRCD1685fa.csv"
+  [[resources.url]]
+  lang = "fa"
+  link = "http://iod.dataset.s3.amazonaws.com/nocrd/NOCRCD1685fa.csv"
 
   [[resources.title]]
   lang = "en" 

--- a/datasets/nocrd1686.toml
+++ b/datasets/nocrd1686.toml
@@ -51,7 +51,9 @@ text = ""
 
 [[resources]]
 
-  url = "http://iod.dataset.s3.amazonaws.com/nocrd/NOCRCD1686fa.csv"
+  [[resources.url]] 
+  lang = "fa"
+  link = "http://iod.dataset.s3.amazonaws.com/nocrd/NOCRCD1686fa.csv"
 
   [[resources.title]]
   lang = "en" 

--- a/datasets/nocrd1687.toml
+++ b/datasets/nocrd1687.toml
@@ -51,7 +51,9 @@ text = ""
 
 [[resources]]
 
-  url = "http://iod.dataset.s3.amazonaws.com/nocrd/NOCRCD1687fa.csv"
+  [[resources.url]] 
+  lang = "en"
+  link = "http://iod.dataset.s3.amazonaws.com/nocrd/NOCRCD1687fa.csv"
 
   [[resources.title]]
   lang = "en" 

--- a/datasets/nocrd1688.toml
+++ b/datasets/nocrd1688.toml
@@ -51,7 +51,9 @@ text = ""
 
 [[resources]]
 
-  url = "http://iod.dataset.s3.amazonaws.com/nocrd/NOCRCD1688fa.csv"
+  [[resources.url]]
+  lang = "fa"
+  link = "http://iod.dataset.s3.amazonaws.com/nocrd/NOCRCD1688fa.csv"
 
   [[resources.title]]
   lang = "en" 

--- a/datasets/nocrd1690.toml
+++ b/datasets/nocrd1690.toml
@@ -51,7 +51,9 @@ text = ""
 
 [[resources]]
 
-  url = "http://iod.dataset.s3.amazonaws.com/nocrd/NOCRCD1690fa.csv"
+  [[resources.url]]
+  lang = "fa"
+  link = "http://iod.dataset.s3.amazonaws.com/nocrd/NOCRCD1690fa.csv"
 
   [[resources.title]]
   lang = "en" 

--- a/datasets/nocrd1691.toml
+++ b/datasets/nocrd1691.toml
@@ -51,7 +51,9 @@ text = ""
 
 [[resources]]
 
-  url = "http://iod.dataset.s3.amazonaws.com/nocrd/NOCRCD1691fa.csv"
+  [[resources.url]] 
+  lang = "fa"
+  link = "http://iod.dataset.s3.amazonaws.com/nocrd/NOCRCD1691fa.csv"
 
   [[resources.title]]
   lang = "en" 

--- a/datasets/nocrd1692.toml
+++ b/datasets/nocrd1692.toml
@@ -51,7 +51,9 @@ text = ""
 
 [[resources]]
 
-  url = "http://iod.dataset.s3.amazonaws.com/nocrd/NOCRCD1692fa.csv"
+  [[resources.url]]
+  lang = "fa"
+  link = "http://iod.dataset.s3.amazonaws.com/nocrd/NOCRCD1692fa.csv"
 
   [[resources.title]]
   lang = "en" 

--- a/datasets/nocrd1693.toml
+++ b/datasets/nocrd1693.toml
@@ -51,7 +51,9 @@ text = "This dataset has been extracted from the annual report of the National O
 
 [[resources]]
 
-  url = "http://iod.dataset.s3.amazonaws.com/nocrd/NOCRCD1693fa.csv"
+  [[resources.url]]
+  lang = "fa"
+  link = "http://iod.dataset.s3.amazonaws.com/nocrd/NOCRCD1693fa.csv"
 
   [[resources.title]]
   lang = "en" 

--- a/datasets/sciehe161fa.toml
+++ b/datasets/sciehe161fa.toml
@@ -51,7 +51,9 @@ text = ""
 
 [[resources]]
 
-  url = "http://iod.dataset.s3.amazonaws.com/ehe/sciehe161fa.csv"
+  [[resources.url]]
+  lang = "fa"
+  link = "http://iod.dataset.s3.amazonaws.com/ehe/sciehe161fa.csv"
 
   [[resources.title]]
   lang = "en" 

--- a/datasets/sciehe162fa.toml
+++ b/datasets/sciehe162fa.toml
@@ -50,7 +50,9 @@ text = ""
 
 [[resources]]
 
-  url = "http://iod.dataset.s3.amazonaws.com/ehe/sciehe162fa.csv"
+  [[resources.url]] 
+  lang = "fa"
+  link = "http://iod.dataset.s3.amazonaws.com/ehe/sciehe162fa.csv"
 
   [[resources.title]]
   lang = "en" 

--- a/datasets/sciehe163fa.toml
+++ b/datasets/sciehe163fa.toml
@@ -50,7 +50,9 @@ text = ""
 
 [[resources]]
 
-  url = "http://iod.dataset.s3.amazonaws.com/ehe/sciehe163fa.csv"
+  [[resources.url]] 
+  lang = "fa"
+  link = "http://iod.dataset.s3.amazonaws.com/ehe/sciehe163fa.csv"
 
   [[resources.title]]
   lang = "en" 

--- a/datasets/sciehe166fa.toml
+++ b/datasets/sciehe166fa.toml
@@ -50,7 +50,9 @@ text = "Unemployment rates in this dataset were calculated based upon Iran's pop
 
 [[resources]]
 
-  url = "http://iod.dataset.s3.amazonaws.com/ehe/sciehe166fa.csv"
+  [[resources.url]] 
+  lang = "fa"
+  link = "http://iod.dataset.s3.amazonaws.com/ehe/sciehe166fa.csv"
 
   [[resources.title]]
   lang = "en" 

--- a/datasets/scipo161fa.toml
+++ b/datasets/scipo161fa.toml
@@ -50,7 +50,9 @@ text = ""
 
 [[resources]]
 
-  url = "http://iod.dataset.s3.amazonaws.com/nocrd1693/scipo161fa.csv"
+  [[resources.url]] 
+  lang = "fa"
+  link = "http://iod.dataset.s3.amazonaws.com/nocrd1693/scipo161fa.csv"
 
   [[resources.title]]
   lang = "en" 

--- a/datasets/scipo162fa.toml
+++ b/datasets/scipo162fa.toml
@@ -50,7 +50,9 @@ text = ""
 
 [[resources]]
 
-  url = "http://iod.dataset.s3.amazonaws.com/nocrd1693/scipo162fa.csv"
+  [[resources.url]] 
+  lang = "fa"
+  link = "http://iod.dataset.s3.amazonaws.com/nocrd1693/scipo162fa.csv"
 
   [[resources.title]]
   lang = "en" 

--- a/datasets/scipo163fa.toml
+++ b/datasets/scipo163fa.toml
@@ -51,7 +51,9 @@ text = "Employment rates in this dataset were calculated based upon Iran's popul
 
 [[resources]]
 
-  url = "http://iod.dataset.s3.amazonaws.com/nocrd1693/scipo163fa.csv"
+  [[resources.url]] 
+  lang = "fa"
+  link = "http://iod.dataset.s3.amazonaws.com/nocrd1693/scipo163fa.csv"
 
   [[resources.title]]
   lang = "en" 

--- a/datasets/scipo164fa.toml
+++ b/datasets/scipo164fa.toml
@@ -50,7 +50,9 @@ text = ""
 
 [[resources]]
 
-  url = "http://iod.dataset.s3.amazonaws.com/nocrd1693/scipo164fa.csv"
+  [[resources.url]] 
+  lang = "fa"
+  link = "http://iod.dataset.s3.amazonaws.com/nocrd1693/scipo164fa.csv"
 
   [[resources.title]]
   lang = "en" 

--- a/spec.md
+++ b/spec.md
@@ -213,11 +213,16 @@ Resources are an array of resource objects. Each resource object has the followi
 ### url
 **REQUIRED**
 
-- `type: URL string`
+- `type: Array of URL object`
+- `url.lang: string`
+- `url.link: URI string`
 
-URL pointing to clean resource data (such as a processed CSV)
+An array of URLs pointing to clean resource data for each language (such as a processed CSV). The language has to be specified, however only one of the languages "fa" or "en" is required to pass validation. This occurs when there is no possible translation for the resource file.
+
 ```
-url = "http://example.com/csv" 
+[[url]] 
+lang = "fa"
+link = "http://example.com/csv" 
 ```
 
 ### code

--- a/validator/spec.json
+++ b/validator/spec.json
@@ -65,8 +65,18 @@
       "properties": {
         "title": {"$ref": "#/definitions/i18n"},
         "url": {
-          "type": "string",
-          "format": "uri"
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "properties": {
+              "lang": {"$ref": "#/definitions/lang"},
+              "link": {
+                "type": "string",
+                "format": "uri"
+              }
+            }
+          }
         },
         "code": {
           "type": "string",


### PR DESCRIPTION
@SoniaAmini This makes resource URLs bilingual.

In `datasets/mhmelih16.toml` I added an example for the `en` language that is probably incorrect. So please make sure to fix that link.